### PR TITLE
ci: switch build workflow to PR checks + manual Docker release dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,19 +1,52 @@
-name: Build
+name: Build and Release
 
 on:
   pull_request:
     branches:
       - development
-  push:
-    branches:
-      - development
+  workflow_dispatch:
+    inputs:
+      build_target:
+        description: "Build target (frontend/backend/both)"
+        required: true
+        default: "both"
+        type: choice
+        options:
+          - frontend
+          - backend
+          - both
+      platform:
+        description: "Docker platform"
+        required: true
+        default: "linux/arm64"
+        type: choice
+        options:
+          - linux/amd64
+          - linux/arm64
+          - linux/amd64,linux/arm64
+      tag:
+        description: "Docker image tag"
+        required: false
+        default: ""
+        type: string
+      channel:
+        description: "Release channel"
+        required: true
+        default: "canary"
+        type: choice
+        options:
+          - stable
+          - canary
+          - none
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   backend:
     name: Backend
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,6 +62,7 @@ jobs:
 
   frontend:
     name: Frontend
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -49,3 +83,88 @@ jobs:
         env:
           NEXT_TELEMETRY_DISABLED: "1"
         run: pnpm -C apps/frontend build
+
+  docker-release:
+    name: Docker Build and Release
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      OWNER: bettaworx
+      BACKEND_IMAGE: ghcr.io/bettaworx/ciel-backend
+      FRONTEND_IMAGE: ghcr.io/bettaworx/ciel-frontend
+      BUILD_TARGET: ${{ inputs.build_target }}
+      PLATFORM: ${{ inputs.platform }}
+      INPUT_TAG: ${{ inputs.tag }}
+      CHANNEL: ${{ inputs.channel }}
+      BUILD_COMMIT: ${{ github.sha }}
+      BUILD_BRANCH: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set image tag
+        run: |
+          if [ -n "${INPUT_TAG}" ]; then
+            echo "TAG=${INPUT_TAG}" >> "$GITHUB_ENV"
+          else
+            echo "TAG=sha-${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push backend
+        if: inputs.build_target == 'backend' || inputs.build_target == 'both'
+        run: |
+          EXTRA_TAGS=()
+          case "$CHANNEL" in
+            stable) EXTRA_TAGS+=(--tag "${BACKEND_IMAGE}:stable" --tag "${BACKEND_IMAGE}:latest") ;;
+            canary) EXTRA_TAGS+=(--tag "${BACKEND_IMAGE}:canary") ;;
+            none) ;;
+          esac
+
+          docker buildx build \
+            --platform "${PLATFORM}" \
+            --file Dockerfile.backend \
+            --build-arg BUILD_COMMIT="${BUILD_COMMIT}" \
+            --build-arg BUILD_BRANCH="${BUILD_BRANCH}" \
+            --cache-from "type=registry,ref=${BACKEND_IMAGE}:canary" \
+            --cache-from "type=registry,ref=${BACKEND_IMAGE}:latest" \
+            --cache-to "type=inline" \
+            --tag "${BACKEND_IMAGE}:${TAG}" \
+            "${EXTRA_TAGS[@]}" \
+            --push \
+            .
+
+      - name: Build and push frontend
+        if: inputs.build_target == 'frontend' || inputs.build_target == 'both'
+        run: |
+          EXTRA_TAGS=()
+          case "$CHANNEL" in
+            stable) EXTRA_TAGS+=(--tag "${FRONTEND_IMAGE}:stable" --tag "${FRONTEND_IMAGE}:latest") ;;
+            canary) EXTRA_TAGS+=(--tag "${FRONTEND_IMAGE}:canary") ;;
+            none) ;;
+          esac
+
+          docker buildx build \
+            --platform "${PLATFORM}" \
+            --file Dockerfile.frontend \
+            --build-arg BUILD_COMMIT="${BUILD_COMMIT}" \
+            --build-arg BUILD_BRANCH="${BUILD_BRANCH}" \
+            --cache-from "type=registry,ref=${FRONTEND_IMAGE}:canary" \
+            --cache-from "type=registry,ref=${FRONTEND_IMAGE}:latest" \
+            --cache-to "type=inline" \
+            --tag "${FRONTEND_IMAGE}:${TAG}" \
+            "${EXTRA_TAGS[@]}" \
+            --push \
+            .
+
+      - name: Prune BuildKit cache
+        run: docker buildx prune --keep-storage=10gb --force


### PR DESCRIPTION
## Summary
- removed `push` trigger from `.github/workflows/build.yml` so build checks no longer run on every commit push to `development`
- kept backend/frontend build checks for `pull_request` events
- added `workflow_dispatch` with inputs to replace the interactive prompts in `scripts/build-push.sh`:
  - `build_target` (`frontend` / `backend` / `both`)
  - `platform` (`linux/amd64` / `linux/arm64` / multi-arch)
  - `tag` (optional, defaults to `sha-<short_sha>`)
  - `channel` (`stable` / `canary` / `none`)
- added a manual `docker-release` job that:
  - logs in to GHCR
  - builds backend/frontend images conditionally from selected target
  - applies channel tags (`stable` + `latest`, `canary`, or none)
  - pushes images and prunes BuildKit cache

## Notes
- release flow mirrors the existing `scripts/build-push.sh` behavior, including cache settings and channel-tag logic
- workflow now requires `packages: write` permission for GHCR push

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0187c4c13c83339c2f2504dea5a494)