### PR TITLE
Use repository owner for GHCR and switch build workflow to manual dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: Build and Release
 
 on:
-  pull_request:
-    branches:
-      - development
   workflow_dispatch:
     inputs:
       build_target:
@@ -44,55 +41,15 @@ permissions:
   packages: write
 
 jobs:
-  backend:
-    name: Backend
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: apps/backend/go.mod
-          cache-dependency-path: apps/backend/go.sum
-
-      - name: Build backend
-        working-directory: apps/backend
-        run: go build ./...
-
-  frontend:
-    name: Frontend
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - name: Enable pnpm
-        run: |
-          corepack enable pnpm
-          corepack prepare pnpm@10.28.0 --activate
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build frontend
-        env:
-          NEXT_TELEMETRY_DISABLED: "1"
-        run: pnpm -C apps/frontend build
-
   docker-release:
     name: Docker Build and Release
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       REGISTRY: ghcr.io
-      OWNER: bettaworx
-      BACKEND_IMAGE: ghcr.io/bettaworx/ciel-backend
-      FRONTEND_IMAGE: ghcr.io/bettaworx/ciel-frontend
+      OWNER: ${{ github.repository_owner }}
+      BACKEND_IMAGE: ghcr.io/${{ github.repository_owner }}/ciel-backend
+      FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/ciel-frontend
       BUILD_TARGET: ${{ inputs.build_target }}
       PLATFORM: ${{ inputs.platform }}
       INPUT_TAG: ${{ inputs.tag }}
@@ -117,7 +74,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push backend


### PR DESCRIPTION
### Motivation

- Reduce automatic CI runs on pull requests and centralize image builds to manual releases to control when multi-platform images are produced.
- Ensure Docker image names and GHCR login use the repository owner to make the workflow portable across forks and organizations.

### Description

- Removed `pull_request` backend and frontend jobs and their `if: github.event_name == 'pull_request'` conditions so those jobs no longer run on PRs. 
- Restrict the Docker build and release job to manual invocation by keeping `if: github.event_name == 'workflow_dispatch'` and expose inputs for `build_target`, `platform`, `tag`, and `channel`. 
- Parameterized `OWNER`, `BACKEND_IMAGE`, and `FRONTEND_IMAGE` to use `${{ github.repository_owner }}` and updated the GHCR login `username` to `${{ github.repository_owner }}` to avoid relying on the actor. 
- Retained tag-setting, `buildx` setup, GHCR login, and the backend multi-platform build-and-push steps with cache and extra channel tags logic.

### Testing

- No automated tests were executed as part of this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a7d9c8048333b92bb5b46e0f8d95)