### PR TITLE
fix(frontend): migrate emoji picker grid to react-window v2 API

### DIFF
--- a/apps/frontend/components/ui/emoji-picker.tsx
+++ b/apps/frontend/components/ui/emoji-picker.tsx
@@ -7,7 +7,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { FixedSizeGrid, type GridChildComponentProps } from "react-window";
+import { Grid, type CellComponentProps } from "react-window";
 
 import { cn } from "@/lib/utils";
 import { useEmojiPickerData } from "@/lib/emoji-picker/use-emoji-picker-data";
@@ -428,7 +428,7 @@ function EmojiGridCell({
   rowIndex,
   style,
   data,
-}: GridChildComponentProps<EmojiGridData>) {
+}: CellComponentProps<EmojiGridData>) {
   const itemIndex = rowIndex * data.columns + columnIndex;
   const item = data.items[itemIndex];
 
@@ -505,18 +505,18 @@ function EmojiGrid({
       className="px-3 sm:px-1"
       data-grid-item-count={items.length}
     >
-      <FixedSizeGrid
+      <Grid
+        cellComponent={EmojiGridCell}
+        cellProps={itemData}
         columnCount={columns}
         columnWidth={metrics.cellSize}
-        height={rowCount * metrics.cellSize}
-        itemData={itemData}
-        overscanRowCount={GRID_OVERSCAN_COUNT}
+        defaultHeight={rowCount * metrics.cellSize}
+        defaultWidth={gridWidth}
+        overscanCount={GRID_OVERSCAN_COUNT}
         rowCount={rowCount}
         rowHeight={metrics.cellSize}
-        width={gridWidth}
-      >
-        {EmojiGridCell}
-      </FixedSizeGrid>
+        style={{ height: rowCount * metrics.cellSize, width: gridWidth }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
### Motivation

- The frontend build failed because `react-window@2` no longer exports `FixedSizeGrid`, causing an import error in the emoji picker component.

### Description

- Replaced the `react-window` imports from `FixedSizeGrid`/`GridChildComponentProps` to the v2 API `Grid`/`CellComponentProps` in `apps/frontend/components/ui/emoji-picker.tsx`.
- Converted the children-based grid renderer to the v2 `Grid` API using `cellComponent` + `cellProps` and adjusted the cell renderer signature accordingly.
- Updated prop names and sizing to v2 semantics (`overscanRowCount` → `overscanCount`, added `defaultHeight`/`defaultWidth` and explicit `style` dimensions, and switched `itemData` → `cellProps`).
- Kept existing layout/behavior logic intact while making the component compatible with `react-window@2`.

### Testing

- Verified the old symbols are removed via `rg` search for `FixedSizeGrid` and `GridChildComponentProps`, which returned no matches in the modified file.
- Ran a production build with `pnpm -C apps/frontend build`; the original `FixedSizeGrid` export error no longer occurred but the build ultimately failed due to unrelated Google Fonts resource resolution/network errors during Next.js font handling, so the overall CI build is still failing for an external dependency issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01bb2081708333a38bec47b0f6f941)