### PR TITLE
ci: upgrade GitHub Actions to Node 24-compatible major versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       BUILD_COMMIT: ${{ github.sha }}
       BUILD_BRANCH: ${{ github.ref_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set image tag
         run: |
@@ -68,10 +68,10 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
         if: matrix.language == 'go'

--- a/.github/workflows/dependabot-go-mod-tidy.yml
+++ b/.github/workflows/dependabot-go-mod-tidy.yml
@@ -22,7 +22,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/go-mod-tidy.yml
+++ b/.github/workflows/go-mod-tidy.yml
@@ -12,7 +12,7 @@ jobs:
     name: Check go mod tidy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
### Motivation
- GitHub is deprecating Node.js 20 on runners and will default to Node.js 24, so Actions that run on Node.js 20 must be moved to versions that support Node.js 24 to avoid future breakage.

### Description
- Bumped `actions/checkout` from `v4` to `v6` across workflows to pick a Node 24-compatible release.
- Updated `docker/setup-buildx-action` from `v3` to `v4` in `/.github/workflows/build.yml`.
- Updated `docker/login-action` from `v3` to `v4` in `/.github/workflows/build.yml`.
- Changed workflow files: `/.github/workflows/build.yml`, `/.github/workflows/codeql.yml`, `/.github/workflows/dependabot-go-mod-tidy.yml`, and `/.github/workflows/go-mod-tidy.yml`.

### Testing
- Ran `rg -n "actions/checkout|docker/login-action|docker/setup-buildx-action" .github/workflows/*.yml` to confirm all references were updated.
- Inspected the modified workflow files to ensure the updates did not alter surrounding configuration or logic.
- All validation commands completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c4b3ca348333bd2d6bb61440c10e)