### PR TITLE
fix(ci): honor selected docker build target in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,10 @@ jobs:
       OWNER: ${{ github.repository_owner }}
       BACKEND_IMAGE: ghcr.io/${{ github.repository_owner }}/ciel-backend
       FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/ciel-frontend
-      BUILD_TARGET: ${{ inputs.build_target }}
-      PLATFORM: ${{ inputs.platform }}
-      INPUT_TAG: ${{ inputs.tag }}
-      CHANNEL: ${{ inputs.channel }}
+      BUILD_TARGET: ${{ github.event.inputs.build_target || inputs.build_target || 'both' }}
+      PLATFORM: ${{ github.event.inputs.platform || inputs.platform || 'linux/arm64' }}
+      INPUT_TAG: ${{ github.event.inputs.tag || inputs.tag || '' }}
+      CHANNEL: ${{ github.event.inputs.channel || inputs.channel || 'canary' }}
       BUILD_COMMIT: ${{ github.sha }}
       BUILD_BRANCH: ${{ github.ref_name }}
     steps:
@@ -78,7 +78,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push backend
-        if: inputs.build_target == 'backend' || inputs.build_target == 'both'
+        if: env.BUILD_TARGET == 'backend' || env.BUILD_TARGET == 'both'
         run: |
           EXTRA_TAGS=()
           case "$CHANNEL" in
@@ -101,7 +101,7 @@ jobs:
             .
 
       - name: Build and push frontend
-        if: inputs.build_target == 'frontend' || inputs.build_target == 'both'
+        if: env.BUILD_TARGET == 'frontend' || env.BUILD_TARGET == 'both'
         run: |
           EXTRA_TAGS=()
           case "$CHANNEL" in


### PR DESCRIPTION
### Motivation
- Workflow-dispatched Docker builds could ignore the chosen `build_target` and build both images, causing unnecessary work and longer runs.
- The root cause was inconsistent input resolution and step `if` checks referencing `inputs.*` directly instead of a single normalized env variable.

### Description
- Updated `.github/workflows/build.yml` to set `env.BUILD_TARGET`, `env.PLATFORM`, `env.INPUT_TAG`, and `env.CHANNEL` using `github.event.inputs` with `inputs` fallbacks and sensible defaults. 
- Changed step conditions to evaluate `env.BUILD_TARGET` (`backend`/`frontend`/`both`) instead of `inputs.build_target` so selected targets are honored. 
- The change is committed with the message `fix(ci): honor selected docker build target in workflow`.

### Testing
- Ran `git diff -- .github/workflows/build.yml` to verify the rendered changes and confirmed the updated env assignments and `if` conditions. (succeeded)
- Ran `nl -ba .github/workflows/build.yml | sed -n '40,140p'` to inspect the conditional blocks and confirm the `env.BUILD_TARGET` usage. (succeeded)
- Changes were committed locally with `git commit` and no CI workflow execution was performed in this environment. (commit succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01d1dd3ad883339b3a604e4855f2eb)