### PR TITLE
build(frontend): enforce frozen lockfile in Docker deps stage

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -9,8 +9,9 @@ COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/frontend/package.json ./apps/frontend/package.json
 COPY packages/kotodoki/package.json ./packages/kotodoki/package.json
 
+# CI/release builds require an up-to-date pnpm-lock.yaml; fail fast on lockfile drift.
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
-    corepack enable pnpm && pnpm install --no-frozen-lockfile
+    corepack enable pnpm && pnpm install --frozen-lockfile
 
 FROM base AS builder
 WORKDIR /app


### PR DESCRIPTION
### Motivation
- Ensure deterministic dependency resolution for the frontend build and prevent lockfile drift during CI/release builds by requiring the checked-in `pnpm-lock.yaml` to be authoritative.

### Description
- In `Dockerfile.frontend`'s `deps` stage replace `pnpm install --no-frozen-lockfile` with `pnpm install --frozen-lockfile` and add a comment stating CI/release builds require an up-to-date `pnpm-lock.yaml` and should fail fast on lockfile drift.

### Testing
- Verified the change with `rg -n "pnpm install --(no-)?frozen-lockfile|pnpm-lock.yaml" Dockerfile.frontend` which showed the updated `--frozen-lockfile` usage and the new comment, and inspected the file with `nl -ba Dockerfile.frontend`; both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01dbc6a4d883339101e8d034a23286)