### PR TITLE
Pin frontend Node 22 slim base image to digest

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM --platform=$BUILDPLATFORM node:22-bookworm-slim AS base
+FROM --platform=$BUILDPLATFORM node:22-bookworm-slim@sha256:868499d55378719bffa87b0ed1f099591823c029b543043c09c2483468e93201 AS base
 
 FROM base AS deps
 WORKDIR /app
@@ -40,7 +40,7 @@ RUN pnpm run build
 # Remove source maps from the build output to avoid exposing source structure
 RUN find .next -name "*.map" -delete
 
-FROM node:22-bookworm-slim AS runner
+FROM node:22-bookworm-slim@sha256:868499d55378719bffa87b0ed1f099591823c029b543043c09c2483468e93201 AS runner
 WORKDIR /app/apps/frontend
 
 ENV NODE_ENV=production

--- a/README.md
+++ b/README.md
@@ -39,6 +39,27 @@ Build the images:
 docker compose build
 ```
 
+### Base image digest update policy
+
+`Dockerfile.frontend` pins `node:22-bookworm-slim` by digest to keep image layers reproducible.
+
+- Update the digest when you intentionally bump Node 22 slim base contents (security patches or monthly maintenance).
+- Keep `base` and `runner` on the same digest in `Dockerfile.frontend`.
+- Recommended update flow:
+
+```bash
+# 1) Fetch current amd64 digest for node:22-bookworm-slim
+TOKEN=$(curl -fsSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/node:pull" | jq -r .token)
+curl -fsSL -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/vnd.oci.image.index.v1+json" \
+  https://registry-1.docker.io/v2/library/node/manifests/22-bookworm-slim \
+  | jq -r '.manifests[] | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest'
+
+# 2) Replace both FROM lines in Dockerfile.frontend
+# 3) Rebuild and verify
+docker compose build frontend
+```
+
 Initialize the database (run once on first setup):
 
 ```bash


### PR DESCRIPTION
### Motivation
- Prevent base-layer drift in `Dockerfile.frontend` to improve reproducible builds and stabilize pulled/final image sizes.
- Provide an operational update policy so maintainers know when and how to refresh the pinned digest.

### Description
- Replaced both `FROM` lines in `Dockerfile.frontend` to use the same digest: `node:22-bookworm-slim@sha256:868499d55378719bffa87b0ed1f099591823c029b543043c09c2483468e93201` for `base` and `runner` stages.
- Added a `Base image digest update policy` section to `README.md` that documents when to update the digest and includes a snippet to fetch the current `amd64/linux` digest from Docker Hub and a recommended rebuild verification step.

### Testing
- Ran `rg` to locate and verify the `FROM` lines in `Dockerfile.frontend`, confirming both stages now reference the digest (succeeded).
- Retrieved the `amd64` digest using the Docker Hub token + `curl` + `jq` flow to determine the digest value used (succeeded).
- Verified the README contains the new policy and the digest-retrieval snippet with `rg` (succeeded).
- Attempted `docker buildx imagetools inspect node:22-bookworm-slim` to cross-check available manifests but the `docker` executable was not present in the environment (failed due to missing `docker`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01dbcff98883339675d6134e31bfa9)