### PR TITLE
frontend: enable Next.js standalone output and slim Docker runner

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -41,7 +41,7 @@ RUN pnpm run build
 RUN find .next -name "*.map" -delete
 
 FROM node:22-bookworm-slim AS runner
-WORKDIR /app/apps/frontend
+WORKDIR /app
 
 ENV NODE_ENV=production
 
@@ -53,20 +53,13 @@ RUN addgroup --system --gid 1001 nodejs \
 ENV HOME=/home/nextjs
 ENV COREPACK_HOME=/home/nextjs/.cache/node/corepack
 
-RUN corepack enable pnpm \
-  && corepack prepare pnpm@10.28.2 --activate
-
-COPY --from=builder /app/apps/frontend/package.json ./package.json
-COPY --from=builder /app/node_modules /app/node_modules
-COPY --from=builder /app/apps/frontend/node_modules ./node_modules
-COPY --from=builder /app/packages/kotodoki/package.json /app/packages/kotodoki/package.json
-COPY --from=builder /app/packages/kotodoki/dist /app/packages/kotodoki/dist
-COPY --from=builder /app/apps/frontend/public ./public
-COPY --from=builder /app/apps/frontend/.next ./.next
+COPY --from=builder /app/apps/frontend/.next/standalone ./
+COPY --from=builder /app/apps/frontend/.next/static ./apps/frontend/.next/static
+COPY --from=builder /app/apps/frontend/public ./apps/frontend/public
 
 USER nextjs
 
 EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
-CMD ["pnpm", "start"]
+CMD ["node", "apps/frontend/server.js"]

--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -15,6 +15,7 @@ const protocol = url.protocol.replace(":", "") as "http" | "https";
 const nextConfig: NextConfig = {
   /* config options here */
   reactCompiler: true,
+  output: "standalone",
 
   // Inject build version info (defaults to "dev" for local development)
   env: {


### PR DESCRIPTION
### Motivation
- Reduce final frontend runner image contents and stabilize layers by using Next.js standalone output.
- Limit the runtime image to only the minimal artifacts the standalone server requires to shrink image size and reduce variability.

### Description
- Enable Next.js standalone output by adding `output: "standalone"` to `apps/frontend/next.config.ts`.
- Switch `Dockerfile.frontend` runner stage to a standalone layout that only copies `.next/standalone`, `.next/static`, and `public` into the final image and set `WORKDIR` to `/app`.
- Remove copying of workspace/root and frontend `node_modules` into the runner stage so the final image does not include full dependency trees.
- Update the runtime command to run the standalone server with `node apps/frontend/server.js`.

### Testing
- Verified presence of `output: "standalone"` and that the runner no longer copies `node_modules` by running `rg "output:|COPY --from=builder /app/node_modules|COPY --from=builder /app/apps/frontend/node_modules|CMD \[\"pnpm\", \"start\"\]" apps/frontend/next.config.ts Dockerfile.frontend` which returned the expected results.
- Inspected the file-level diff for `apps/frontend/next.config.ts` and `Dockerfile.frontend` to confirm only the intended changes were made and the runtime `CMD` was updated.
- All automated checks/grep/diff validations completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01dbcec8748333bce0c4b989031ab9)