### PR TITLE
ci: add ciel-frontend image size regression check

### DIFF
--- a/.github/workflows/frontend-image-size.yml
+++ b/.github/workflows/frontend-image-size.yml
@@ -1,0 +1,88 @@
+name: Frontend Image Size Check
+
+on:
+  pull_request:
+    paths:
+      - 'apps/frontend/**'
+      - 'Dockerfile.frontend'
+      - '.github/workflows/frontend-image-size.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/frontend/**'
+      - 'Dockerfile.frontend'
+      - '.github/workflows/frontend-image-size.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check-frontend-image-size:
+    name: Check ciel-frontend image size growth
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME_HEAD: ciel-frontend:size-head
+      IMAGE_NAME_BASE: ciel-frontend:size-base
+      SIZE_THRESHOLD_BYTES: 20971520 # 20 MiB
+    steps:
+      - name: Checkout HEAD
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build HEAD image (local)
+        run: |
+          docker buildx build \
+            --platform linux/amd64 \
+            --file Dockerfile.frontend \
+            --tag "${IMAGE_NAME_HEAD}" \
+            --load \
+            .
+
+      - name: Build baseline image from main branch (local)
+        run: |
+          git fetch --no-tags --depth=1 origin main
+          git worktree add /tmp/ciel-main origin/main
+
+          docker buildx build \
+            --platform linux/amd64 \
+            --file /tmp/ciel-main/Dockerfile.frontend \
+            --tag "${IMAGE_NAME_BASE}" \
+            --load \
+            /tmp/ciel-main
+
+      - name: Compare image size against baseline
+        run: |
+          set -euo pipefail
+
+          head_size=$(docker image inspect "${IMAGE_NAME_HEAD}" --format '{{.Size}}')
+          base_size=$(docker image inspect "${IMAGE_NAME_BASE}" --format '{{.Size}}')
+
+          delta=$((head_size - base_size))
+          threshold="${SIZE_THRESHOLD_BYTES}"
+
+          mib() {
+            awk -v bytes="$1" 'BEGIN { printf "%.2f", bytes/1024/1024 }'
+          }
+
+          {
+            echo "### ciel-frontend image size report"
+            echo
+            echo "Measured metric: **local Docker image size** from \
+\`docker image inspect ... --format {{.Size}}\` (bytes)."
+            echo "(Not compressed transfer size / pushed layer size.)"
+            echo
+            echo "- Baseline (origin/main): ${base_size} bytes ($(mib "$base_size") MiB)"
+            echo "- Current (HEAD): ${head_size} bytes ($(mib "$head_size") MiB)"
+            echo "- Delta (HEAD - baseline): ${delta} bytes ($(mib "$delta") MiB)"
+            echo "- Allowed increase: ${threshold} bytes ($(mib "$threshold") MiB)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$delta" -gt "$threshold" ]; then
+            echo "Image size increase exceeded threshold: +${delta} bytes > +${threshold} bytes"
+            exit 1
+          fi


### PR DESCRIPTION
### Motivation
- 意図しないフロントエンド Docker イメージの肥大化を継続的に検出して PR を失敗させるガードを追加するため。 
- 計測指標は要求どおり `docker image inspect` の `Size`（ローカル image size、バイト）を用いるため。 
- 同一ランで比較可能な基準として `origin/main` をビルドして差分を算出するため。 

### Description
- 新しい GitHub Actions ワークフローを追加した：`.github/workflows/frontend-image-size.yml`。 
- CI 内で HEAD と `origin/main`（`git worktree` 経由）をそれぞれ `docker buildx build --load` でローカルにビルドし、`docker image inspect --format '{{.Size}}'` でサイズを取得して差分を計算するようにした。 
- 許容増分は `SIZE_THRESHOLD_BYTES=20971520`（20 MiB）に設定し、差分が閾値を超えた場合は `exit 1` でジョブを失敗させるロジックを追加した。 
- 実行トリガーは frontend ソース／`Dockerfile.frontend`／このワークフロー自身への変更を対象とする `pull_request` と `main` への `push` に設定し、Step Summary に「ローカル image size を計測している」旨を明示した。 

### Testing
- この PR に対するユニット／統合の自動テストは実行していないが、追加したワークフローは GitHub Actions 上で `pull_request` と `push` 時に自動実行されるようになっている。 
- ローカルでのリポジトリ操作確認として `rg` による検索と `git diff --check`／`git status` を実行して差分作成とコミットが正常に行えることを確認した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01dbd130ac8333b48ffaa329e15968)