### PR TITLE
native_app: add Google Fonts layer and apply Noto Sans/JP

### DIFF
--- a/apps/native_app/lib/main.dart
+++ b/apps/native_app/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'theme/app_theme.dart';
+
 void main() {
   runApp(const MyApp());
 }
@@ -7,115 +9,47 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: .fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      title: 'Ciel Native App',
+      theme: AppTheme.light(),
+      home: const HomePage(),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
+    final textTheme = Theme.of(context).textTheme;
+
     return Scaffold(
       appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
+        title: const Text('Ciel'),
       ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
+      body: Padding(
+        padding: const EdgeInsets.all(24),
         child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: .center,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text('You have pushed the button this many times:'),
+            Text('Noto Sans', style: textTheme.headlineSmall),
+            const SizedBox(height: 8),
             Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
+              'The quick brown fox jumps over the lazy dog.',
+              style: textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 24),
+            Text('Noto Sans JP', style: textTheme.headlineSmall),
+            const SizedBox(height: 8),
+            Text(
+              '素早い茶色の狐が怠惰な犬を飛び越える。',
+              style: textTheme.bodyLarge,
             ),
           ],
         ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
       ),
     );
   }

--- a/apps/native_app/lib/theme/app_fonts.dart
+++ b/apps/native_app/lib/theme/app_fonts.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class AppFonts {
+  const AppFonts._();
+
+  static TextTheme textTheme() {
+    final base = ThemeData.light().textTheme;
+
+    final latin = GoogleFonts.notoSansTextTheme(base);
+    return GoogleFonts.notoSansJpTextTheme(latin);
+  }
+}

--- a/apps/native_app/lib/theme/app_theme.dart
+++ b/apps/native_app/lib/theme/app_theme.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+import 'app_fonts.dart';
+
+class AppTheme {
+  const AppTheme._();
+
+  static ThemeData light() {
+    return ThemeData(
+      useMaterial3: true,
+      colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
+      textTheme: AppFonts.textTheme(),
+    );
+  }
+}

--- a/apps/native_app/pubspec.yaml
+++ b/apps/native_app/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  google_fonts: ^6.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- introduced a dedicated typography layer for the Flutter native app
- added `AppFonts` to fetch and compose Google Fonts text themes
- added `AppTheme` to centralize Material theme configuration
- wired the app root to use the shared theme layer
- updated app UI sample text to verify both Latin and Japanese font rendering
- added `google_fonts` dependency to `pubspec.yaml`

## Details
- `apps/native_app/lib/theme/app_fonts.dart`
  - adds `AppFonts.textTheme()` using:
    - `GoogleFonts.notoSansTextTheme(...)`
    - `GoogleFonts.notoSansJpTextTheme(...)`
- `apps/native_app/lib/theme/app_theme.dart`
  - adds `AppTheme.light()` and applies `AppFonts.textTheme()`
- `apps/native_app/lib/main.dart`
  - replaces default counter template with a simple screen that uses the shared theme and shows both English and Japanese sample strings
- `apps/native_app/pubspec.yaml`
  - adds `google_fonts: ^6.3.2`

## Notes
- This PR focuses on creating and applying the font-loading layer first, as requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a028f60d7f48333bf55c4e578f0c6ee)