### PR TITLE
feat(native_app): add persisted LocaleController and wire app locale at startup

### DIFF
--- a/apps/native_app/lib/locale/locale_controller.dart
+++ b/apps/native_app/lib/locale/locale_controller.dart
@@ -1,0 +1,57 @@
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LocaleController extends ChangeNotifier {
+  LocaleController({SharedPreferences? preferences})
+    : _preferencesFuture =
+          preferences != null
+              ? Future<SharedPreferences>.value(preferences)
+              : SharedPreferences.getInstance();
+
+  static const String storageKey = 'app_locale';
+  static const List<Locale> supportedLocales = [Locale('en'), Locale('ja')];
+
+  final Future<SharedPreferences> _preferencesFuture;
+
+  Locale _locale = supportedLocales.first;
+  Locale get locale => _locale;
+
+  Future<void> init() async {
+    final preferences = await _preferencesFuture;
+    final savedLanguageCode = preferences.getString(storageKey);
+
+    if (savedLanguageCode != null) {
+      _locale = _resolveLocale(Locale(savedLanguageCode));
+      return;
+    }
+
+    final systemLocale = PlatformDispatcher.instance.locale;
+    _locale = _resolveLocale(systemLocale);
+    await preferences.setString(storageKey, _locale.languageCode);
+  }
+
+  Future<void> setLocale(Locale locale) async {
+    final resolvedLocale = _resolveLocale(locale);
+
+    if (_locale == resolvedLocale) {
+      return;
+    }
+
+    _locale = resolvedLocale;
+    final preferences = await _preferencesFuture;
+    await preferences.setString(storageKey, _locale.languageCode);
+    notifyListeners();
+  }
+
+  Locale _resolveLocale(Locale locale) {
+    for (final supportedLocale in supportedLocales) {
+      if (supportedLocale.languageCode == locale.languageCode) {
+        return supportedLocale;
+      }
+    }
+
+    return supportedLocales.first;
+  }
+}

--- a/apps/native_app/lib/main.dart
+++ b/apps/native_app/lib/main.dart
@@ -2,34 +2,50 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
+import 'locale/locale_controller.dart';
 import 'theme/app_theme.dart';
 
-void main() {
-  runApp(const MyApp());
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  final localeController = LocaleController();
+  await localeController.init();
+
+  runApp(MyApp(localeController: localeController));
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  const MyApp({super.key, required this.localeController});
+
+  final LocaleController localeController;
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
-      theme: AppTheme.light(),
-      localizationsDelegates: const [
-        AppLocalizations.delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ],
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: const HomePage(),
+    return AnimatedBuilder(
+      animation: localeController,
+      builder: (context, _) {
+        return MaterialApp(
+          onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
+          theme: AppTheme.light(),
+          locale: localeController.locale,
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+          ],
+          supportedLocales: LocaleController.supportedLocales,
+          home: HomePage(localeController: localeController),
+        );
+      },
     );
   }
 }
 
 class HomePage extends StatelessWidget {
-  const HomePage({super.key});
+  const HomePage({super.key, required this.localeController});
+
+  final LocaleController localeController;
 
   @override
   Widget build(BuildContext context) {
@@ -57,6 +73,20 @@ class HomePage extends StatelessWidget {
             Text(
               l10n.notoSansJpDescription,
               style: textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 24),
+            Wrap(
+              spacing: 8,
+              children: [
+                FilledButton(
+                  onPressed: () => localeController.setLocale(const Locale('en')),
+                  child: const Text('English'),
+                ),
+                FilledButton(
+                  onPressed: () => localeController.setLocale(const Locale('ja')),
+                  child: const Text('日本語'),
+                ),
+              ],
             ),
           ],
         ),


### PR DESCRIPTION
### Motivation
- Persist and apply the user's selected app locale across launches and ensure the app starts with a resolved locale (saved → system → fallback) so UI texts render in the expected language.
- Make locale changes reflect immediately in the running app without a full restart.

### Description
- Add `LocaleController` at `apps/native_app/lib/locale/locale_controller.dart` implementing `ChangeNotifier`, persisting the language code under `app_locale` in `SharedPreferences`, resolving saved/system locales, and falling back to `en` for unsupported languages.
- Make `main()` `async`, call `WidgetsFlutterBinding.ensureInitialized()`, initialize `LocaleController.init()` before `runApp`, and pass the controller into the app.
- Wire `MaterialApp(locale: localeController.locale, supportedLocales: LocaleController.supportedLocales, ...)` and rebuild on changes via `AnimatedBuilder` so `notifyListeners()` triggers immediate UI updates.
- Add simple language switch buttons on `HomePage` that call `localeController.setLocale(...)` to exercise persistence and live updates; `supportedLocales` now contains `Locale('en')` and `Locale('ja')`.

### Testing
- Attempted to run formatter and tests with `dart format lib/main.dart lib/locale/locale_controller.dart && flutter test`, but the environment lacks the Dart/Flutter toolchain so `dart: command not found` caused the check to fail.
- No automated unit or integration tests were added or executed in this rollout due to the unavailable toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0291d6bbe8833399dcaf0f9e3db602)