### PR TITLE
Add localization test UI with pluralized counter and language switcher

### DIFF
--- a/apps/native_app/lib/l10n/app_en.arb
+++ b/apps/native_app/lib/l10n/app_en.arb
@@ -1,9 +1,28 @@
 {
   "appTitle": "Ciel Native App",
-  "homeAppBarTitle": "Ciel",
-  "notoSansTitle": "Noto Sans",
-  "notoSansDescription": "The quick brown fox jumps over the lazy dog.",
-  "notoSansJpTitle": "Noto Sans JP",
-  "notoSansJpDescription": "A quick brown fox jumps over a lazy dog in Japanese.",
+  "homeTitle": "Localization Test",
+  "localizationTestDescription": "Use this page to verify localized text and language switching.",
+  "counterPrompt": "You have pushed the button this many times:",
+  "counterValue": "{count, plural, =0{0 times} =1{1 time} other{{count} times}}",
+  "@counterValue": {
+    "description": "Current number of button presses",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "languageSwitcherTitle": "Language",
+  "currentLocaleLabel": "Current locale: {locale}",
+  "@currentLocaleLabel": {
+    "description": "Currently selected locale",
+    "placeholders": {
+      "locale": {
+        "type": "String"
+      }
+    }
+  },
+  "languageEnglish": "English",
+  "languageJapanese": "Japanese",
   "incrementTooltip": "Increment counter"
 }

--- a/apps/native_app/lib/l10n/app_ja.arb
+++ b/apps/native_app/lib/l10n/app_ja.arb
@@ -1,9 +1,28 @@
 {
   "appTitle": "Ciel ネイティブアプリ",
-  "homeAppBarTitle": "Ciel",
-  "notoSansTitle": "Noto Sans",
-  "notoSansDescription": "素早い茶色の狐が怠惰な犬を飛び越える。",
-  "notoSansJpTitle": "Noto Sans JP",
-  "notoSansJpDescription": "日本語の表示サンプルです。",
+  "homeTitle": "ローカライズ確認",
+  "localizationTestDescription": "このページで翻訳文言と言語切り替えを確認できます。",
+  "counterPrompt": "ボタンを押した回数:",
+  "counterValue": "{count, plural, =0{0回} =1{1回} other{{count}回}}",
+  "@counterValue": {
+    "description": "ボタン押下回数",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "languageSwitcherTitle": "言語",
+  "currentLocaleLabel": "現在のロケール: {locale}",
+  "@currentLocaleLabel": {
+    "description": "現在選択中のロケール",
+    "placeholders": {
+      "locale": {
+        "type": "String"
+      }
+    }
+  },
+  "languageEnglish": "英語",
+  "languageJapanese": "日本語",
   "incrementTooltip": "カウンターを増やす"
 }

--- a/apps/native_app/lib/main.dart
+++ b/apps/native_app/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'locale/locale_controller.dart';
@@ -25,16 +24,12 @@ class MyApp extends StatelessWidget {
       animation: localeController,
       builder: (context, _) {
         return MaterialApp(
+          title: 'Ciel Native App',
           onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
           theme: AppTheme.light(),
           locale: localeController.locale,
-          localizationsDelegates: const [
-            AppLocalizations.delegate,
-            GlobalMaterialLocalizations.delegate,
-            GlobalCupertinoLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-          ],
-          supportedLocales: LocaleController.supportedLocales,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: HomePage(localeController: localeController),
         );
       },
@@ -42,49 +37,60 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class HomePage extends StatelessWidget {
+class HomePage extends StatefulWidget {
   const HomePage({super.key, required this.localeController});
 
   final LocaleController localeController;
 
   @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  int _counter = 0;
+
+  void _incrementCounter() {
+    setState(() {
+      _counter++;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
     final l10n = AppLocalizations.of(context)!;
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(l10n.homeAppBarTitle),
+        title: Text(l10n.homeTitle),
       ),
       body: Padding(
         padding: const EdgeInsets.all(24),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(l10n.notoSansTitle, style: textTheme.headlineSmall),
+            Text(l10n.localizationTestDescription, style: Theme.of(context).textTheme.bodyLarge),
+            const SizedBox(height: 24),
+            Text(l10n.counterPrompt, style: Theme.of(context).textTheme.bodyLarge),
+            const SizedBox(height: 8),
+            Text(l10n.counterValue(_counter), style: Theme.of(context).textTheme.headlineMedium),
+            const SizedBox(height: 24),
+            Text(l10n.languageSwitcherTitle, style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 8),
             Text(
-              l10n.notoSansDescription,
-              style: textTheme.bodyLarge,
+              l10n.currentLocaleLabel(Localizations.localeOf(context).toLanguageTag()),
+              style: Theme.of(context).textTheme.bodyMedium,
             ),
-            const SizedBox(height: 24),
-            Text(l10n.notoSansJpTitle, style: textTheme.headlineSmall),
-            const SizedBox(height: 8),
-            Text(
-              l10n.notoSansJpDescription,
-              style: textTheme.bodyLarge,
-            ),
-            const SizedBox(height: 24),
+            const SizedBox(height: 12),
             Wrap(
               spacing: 8,
               children: [
                 FilledButton(
-                  onPressed: () => localeController.setLocale(const Locale('en')),
-                  child: const Text('English'),
+                  onPressed: () => widget.localeController.setLocale(const Locale('en')),
+                  child: Text(l10n.languageEnglish),
                 ),
                 FilledButton(
-                  onPressed: () => localeController.setLocale(const Locale('ja')),
-                  child: const Text('日本語'),
+                  onPressed: () => widget.localeController.setLocale(const Locale('ja')),
+                  child: Text(l10n.languageJapanese),
                 ),
               ],
             ),
@@ -92,7 +98,7 @@ class HomePage extends StatelessWidget {
         ),
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () {},
+        onPressed: _incrementCounter,
         tooltip: l10n.incrementTooltip,
         child: const Icon(Icons.add),
       ),


### PR DESCRIPTION
### Motivation

- Replace previous font/sample strings with a small localization test page to verify translations and runtime language switching.
- Add a localized, plural-aware counter display to exercise parameterized translations and placeholders.
- Use the generated localization delegates and supported locales to streamline Flutter localization wiring.

### Description

- Updated `apps/native_app/lib/l10n/app_en.arb` and `apps/native_app/lib/l10n/app_ja.arb` to add keys for `homeTitle`, `localizationTestDescription`, `counterPrompt`, a plural `counterValue` with a `count` placeholder, `languageSwitcherTitle`, `currentLocaleLabel` with a `locale` placeholder, and `languageEnglish`/`languageJapanese` texts.
- Modified `apps/native_app/lib/main.dart` to set the app `title`, use `AppLocalizations.localizationsDelegates` and `AppLocalizations.supportedLocales`, remove the explicit `flutter_localizations` import, and update the home page to consume the new localized strings.
- Converted `HomePage` from `StatelessWidget` to `StatefulWidget`, added an integer `_counter` and `_incrementCounter()` to update it, wired the FAB to increment the counter and display `counterValue`, and updated language buttons to call `widget.localeController.setLocale(...)` and show localized labels.

### Testing

- Ran `flutter analyze` against the project and the analyzer reported no issues.
- Ran `flutter test` and all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0292aaed0083339313c7578cf220e6)