### PR TITLE
native_app: personalize app name to Ciel

### DIFF
--- a/apps/native_app/android/app/src/main/AndroidManifest.xml
+++ b/apps/native_app/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="native_app"
+        android:label="Ciel"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/apps/native_app/ios/Runner/Info.plist
+++ b/apps/native_app/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Native App</string>
+	<string>Ciel</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>native_app</string>
+	<string>Ciel</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/apps/native_app/lib/l10n/app_en.arb
+++ b/apps/native_app/lib/l10n/app_en.arb
@@ -1,5 +1,5 @@
 {
-  "appTitle": "Ciel Native App",
+  "appTitle": "Ciel",
   "homeTitle": "Localization Test",
   "localizationTestDescription": "Use this page to verify localized text and language switching.",
   "counterPrompt": "You have pushed the button this many times:",

--- a/apps/native_app/lib/l10n/app_ja.arb
+++ b/apps/native_app/lib/l10n/app_ja.arb
@@ -1,5 +1,5 @@
 {
-  "appTitle": "Ciel ネイティブアプリ",
+  "appTitle": "Ciel",
   "homeTitle": "ローカライズ確認",
   "localizationTestDescription": "このページで翻訳文言と言語切り替えを確認できます。",
   "counterPrompt": "ボタンを押した回数:",

--- a/apps/native_app/lib/main.dart
+++ b/apps/native_app/lib/main.dart
@@ -24,7 +24,7 @@ class MyApp extends StatelessWidget {
       animation: localeController,
       builder: (context, _) {
         return MaterialApp(
-          title: 'Ciel Native App',
+          title: 'Ciel',
           onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
           theme: AppTheme.light(),
           locale: localeController.locale,


### PR DESCRIPTION
### Motivation
- Standardize the mobile app branding to use the project name `Ciel` and remove occurrences of phrases like "Ciel ネイティブアプリ" / "Ciel Native App" to keep UI text concise and consistent across locales.

### Description
- Change the Flutter app `MaterialApp` title to `Ciel` in `apps/native_app/lib/main.dart` by updating the `title` property.
- Update localized `appTitle` entries to `Ciel` in `apps/native_app/lib/l10n/app_en.arb` and `apps/native_app/lib/l10n/app_ja.arb` so both languages show the unified name.
- Set the Android application label to `Ciel` by updating `android:label` in `apps/native_app/android/app/src/main/AndroidManifest.xml`.
- Set the iOS display and bundle names to `Ciel` by updating `CFBundleDisplayName` and `CFBundleName` in `apps/native_app/ios/Runner/Info.plist`.

### Testing
- Ran repository search with `rg` for previous app-name strings and verified updated occurrences were present only where intended, and removed where required. 
- Inspected the modified file diffs and checked the updated localization ARB files to confirm `appTitle` is now `Ciel` for both languages. 
- No unit or integration tests were modified or required for these textual/metadata changes and the verification steps above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0293e3ae1c8333a54eec287b2b1891)