### PR TITLE
Add lucide_icons to native_app and wire initial usage

### DIFF
--- a/apps/native_app/lib/main.dart
+++ b/apps/native_app/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'l10n/app_localizations.dart';
 
 import 'locale/locale_controller.dart';

--- a/apps/native_app/lib/main.dart
+++ b/apps/native_app/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons/lucide_icons.dart';
 import 'l10n/app_localizations.dart';
 
 import 'locale/locale_controller.dart';
@@ -100,7 +101,7 @@ class _HomePageState extends State<HomePage> {
       floatingActionButton: FloatingActionButton(
         onPressed: _incrementCounter,
         tooltip: l10n.incrementTooltip,
-        child: const Icon(Icons.add),
+        child: const Icon(LucideIcons.plus),
       ),
     );
   }

--- a/apps/native_app/pubspec.lock
+++ b/apps/native_app/pubspec.lock
@@ -405,6 +405,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  lucide_icons_flutter:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: HEAD
+      resolved-ref: "07d8ff04f1052dcadf6d0b95811b6983cf683954"
+      url: "https://github.com/vqh2602/lucide-flutter-main.git"
+    source: git
+    version: "3.1.13"
   matcher:
     dependency: transitive
     description:

--- a/apps/native_app/pubspec.yaml
+++ b/apps/native_app/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   google_fonts: ^6.3.2
-  lucide_icons:
+  lucide_icons_flutter:
     git:
       url: https://github.com/vqh2602/lucide-flutter-main.git
 

--- a/apps/native_app/pubspec.yaml
+++ b/apps/native_app/pubspec.yaml
@@ -39,6 +39,9 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   google_fonts: ^6.3.2
+  lucide_icons:
+    git:
+      url: https://github.com/vqh2602/lucide-flutter-main.git
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Added `lucide_icons` to `apps/native_app/pubspec.yaml` using the GitHub repository source.
- Imported `lucide_icons` in `apps/native_app/lib/main.dart`.
- Replaced the floating action button icon from `Icons.add` to `LucideIcons.plus` to verify package usage in-app.

## Notes
- Attempted to run dependency install with `flutter pub get`, but `flutter` is not available in this environment (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02b9883ff883339c2209de39119eb2)