### PR TITLE
Add MFM test page and integrate mfm/mfm_parser into native_app

### DIFF
--- a/apps/native_app/lib/main.dart
+++ b/apps/native_app/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
-import 'l10n/app_localizations.dart';
+import 'package:mfm/mfm.dart';
+import 'package:mfm_parser/mfm_parser.dart';
 
+import 'l10n/app_localizations.dart';
 import 'locale/locale_controller.dart';
 import 'theme/app_theme.dart';
 
@@ -63,44 +65,125 @@ class _HomePageState extends State<HomePage> {
       appBar: AppBar(
         title: Text(l10n.homeTitle),
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(l10n.localizationTestDescription, style: Theme.of(context).textTheme.bodyLarge),
-            const SizedBox(height: 24),
-            Text(l10n.counterPrompt, style: Theme.of(context).textTheme.bodyLarge),
-            const SizedBox(height: 8),
-            Text(l10n.counterValue(_counter), style: Theme.of(context).textTheme.headlineMedium),
-            const SizedBox(height: 24),
-            Text(l10n.languageSwitcherTitle, style: Theme.of(context).textTheme.titleMedium),
-            const SizedBox(height: 8),
-            Text(
-              l10n.currentLocaleLabel(Localizations.localeOf(context).toLanguageTag()),
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
-            const SizedBox(height: 12),
-            Wrap(
-              spacing: 8,
+      body: Stack(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                FilledButton(
-                  onPressed: () => widget.localeController.setLocale(const Locale('en')),
-                  child: Text(l10n.languageEnglish),
+                Text(l10n.localizationTestDescription, style: Theme.of(context).textTheme.bodyLarge),
+                const SizedBox(height: 24),
+                Text(l10n.counterPrompt, style: Theme.of(context).textTheme.bodyLarge),
+                const SizedBox(height: 8),
+                Text(l10n.counterValue(_counter), style: Theme.of(context).textTheme.headlineMedium),
+                const SizedBox(height: 24),
+                Text(l10n.languageSwitcherTitle, style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: 8),
+                Text(
+                  l10n.currentLocaleLabel(Localizations.localeOf(context).toLanguageTag()),
+                  style: Theme.of(context).textTheme.bodyMedium,
                 ),
-                FilledButton(
-                  onPressed: () => widget.localeController.setLocale(const Locale('ja')),
-                  child: Text(l10n.languageJapanese),
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 8,
+                  children: [
+                    FilledButton(
+                      onPressed: () => widget.localeController.setLocale(const Locale('en')),
+                      child: Text(l10n.languageEnglish),
+                    ),
+                    FilledButton(
+                      onPressed: () => widget.localeController.setLocale(const Locale('ja')),
+                      child: Text(l10n.languageJapanese),
+                    ),
+                  ],
                 ),
               ],
             ),
-          ],
-        ),
+          ),
+          Positioned(
+            left: 16,
+            bottom: 16,
+            child: FloatingActionButton.extended(
+              onPressed: () {
+                Navigator.of(context).push(MaterialPageRoute<void>(builder: (_) => const MfmTestPage()));
+              },
+              icon: const Icon(Icons.science_outlined),
+              label: const Text('MFM Test'),
+            ),
+          ),
+        ],
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: _incrementCounter,
         tooltip: l10n.incrementTooltip,
         child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+
+
+class MfmTestPage extends StatefulWidget {
+  const MfmTestPage({super.key});
+
+  @override
+  State<MfmTestPage> createState() => _MfmTestPageState();
+}
+
+class _MfmTestPageState extends State<MfmTestPage> {
+  static const String _initialText = r'''
+<center>$[x2 **MFM Renderer Test**]</center>
+
+Hello @ciel!
+This is **bold**, <small>small</small>, and $[rainbow colorful text].
+Check URL: <https://example.com>
+#ciel #mfm
+''';
+
+  final TextEditingController _controller = TextEditingController(text: _initialText);
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final parsedNodes = const MfmParser().parse(_controller.text);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('MFM Test Page')),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            TextField(
+              controller: _controller,
+              minLines: 6,
+              maxLines: 12,
+              decoration: const InputDecoration(
+                labelText: 'MFM Input',
+                border: OutlineInputBorder(),
+              ),
+              onChanged: (_) => setState(() {}),
+            ),
+            const SizedBox(height: 16),
+            Text('Parsed node count: ${parsedNodes.length}'),
+            const SizedBox(height: 8),
+            SelectableText(parsedNodes.toString()),
+            const SizedBox(height: 16),
+            const Divider(),
+            const SizedBox(height: 8),
+            const Text('Rendered by mfm package:'),
+            const SizedBox(height: 8),
+            Mfm(
+              _controller.text,
+              shrinkWrap: true,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/apps/native_app/lib/main.dart
+++ b/apps/native_app/lib/main.dart
@@ -179,7 +179,7 @@ Check URL: <https://example.com>
             const Text('Rendered by mfm package:'),
             const SizedBox(height: 8),
             Mfm(
-              _controller.text,
+              mfmText: _controller.text,
               shrinkWrap: true,
             ),
           ],

--- a/apps/native_app/lib/main.dart
+++ b/apps/native_app/lib/main.dart
@@ -180,7 +180,6 @@ Check URL: <https://example.com>
             const SizedBox(height: 8),
             Mfm(
               mfmText: _controller.text,
-              shrinkWrap: true,
             ),
           ],
         ),

--- a/apps/native_app/pubspec.lock
+++ b/apps/native_app/pubspec.lock
@@ -161,6 +161,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  colorfilter_generator:
+    dependency: transitive
+    description:
+      name: colorfilter_generator
+      sha256: ccc2995e440b1d828d55d99150e7cad64624f3cb4a1e235000de3f93cf10d35c
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.8"
   convert:
     dependency: transitive
     description:
@@ -193,6 +201,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.6"
+  dotted_border:
+    dependency: transitive
+    description:
+      name: dotted_border
+      sha256: "99b091ec6891ba0c5331fdc2b502993c7c108f898995739a73c6845d71dad70c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -421,6 +437,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  matrix2d:
+    dependency: transitive
+    description:
+      name: matrix2d
+      sha256: "188718dd3bc2a31e372cfd0791b0f77f4f13ea76164147342cc378d9132949e7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   meta:
     dependency: transitive
     description:
@@ -429,6 +453,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  mfm:
+    dependency: "direct main"
+    description:
+      name: mfm
+      sha256: "1e7f9e02eb7536d5bd127ba19da568262cb064ea79bf461e11257930d53c5528"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.9"
+  mfm_parser:
+    dependency: "direct main"
+    description:
+      name: mfm_parser
+      sha256: "733a69d14f75c8c15c5b961f2428bd42c7118bbe0b271c03666a7941435fb691"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.6"
   mime:
     dependency: transitive
     description:

--- a/apps/native_app/pubspec.yaml
+++ b/apps/native_app/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   shared_preferences: ^2.5.3
+  mfm: ^1.0.9
+  mfm_parser: ^1.0.6
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
### Motivation
- Provide an in-app playground to compose, parse and render MFM content for development and debugging.
- Integrate the `mfm` rendering package and `mfm_parser` so the app can parse and display MFM without external tooling.

### Description
- Added `mfm: ^1.0.9` and `mfm_parser: ^1.0.6` to `apps/native_app/pubspec.yaml` and imported `package:mfm/mfm.dart` and `package:mfm_parser/mfm_parser.dart` in `apps/native_app/lib/main.dart`.
- Introduced `MfmTestPage` widget that provides a multi-line `TextField`, parses the input with `MfmParser`, shows parsed node info, and renders the content with `Mfm`.
- Added an extended `FloatingActionButton` to the app `Scaffold` positioned via a `Stack/Positioned` that navigates to the `MfmTestPage` when tapped, and refactored the existing body layout slightly into the new `Stack` structure.
- Minor import reordering and UI adjustments (language switcher wrapped, initial MFM sample text and controller lifecycle management).

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02bba18270833390299cd1f8980c84)