### PR TITLE
Add avatar crop flow to setup wizard

### DIFF
--- a/apps/frontend/components/setup/AvatarStep.tsx
+++ b/apps/frontend/components/setup/AvatarStep.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
+import { ImageCropDialog } from "@/components/shared/ImageCropDialog";
 import { User, Upload } from "lucide-react";
 import Image from "next/image";
 
@@ -20,19 +21,30 @@ export function AvatarStep({
   const t = useTranslations();
   const [preview, setPreview] = useState<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [cropDialogOpen, setCropDialogOpen] = useState(false);
+  const [cropImageSrc, setCropImageSrc] = useState<string | null>(null);
+  const [pendingCropFile, setPendingCropFile] = useState<File | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
-    // Preview
     const reader = new FileReader();
     reader.onloadend = () => {
-      setPreview(reader.result as string);
+      setCropImageSrc(reader.result as string);
+      setPendingCropFile(file);
+      setCropDialogOpen(true);
     };
     reader.readAsDataURL(file);
-    setSelectedFile(file);
+  };
+
+  const handleCropComplete = (croppedFile: File) => {
+    setPreview(URL.createObjectURL(croppedFile));
+    setSelectedFile(croppedFile);
+    setCropDialogOpen(false);
+    setCropImageSrc(null);
+    setPendingCropFile(null);
   };
 
   const handleUploadClick = () => {
@@ -97,6 +109,18 @@ export function AvatarStep({
           </div>
         </div>
       </form>
+
+      {cropDialogOpen && cropImageSrc && pendingCropFile && (
+        <ImageCropDialog
+          open={cropDialogOpen}
+          onOpenChange={setCropDialogOpen}
+          imageSrc={cropImageSrc}
+          aspectMode={{ mode: "fixed", aspect: 1 }}
+          title={t("setup.avatar.cropTitle")}
+          originalFile={pendingCropFile}
+          onCropComplete={handleCropComplete}
+        />
+      )}
     </div>
   );
 }

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -543,7 +543,8 @@
       "description": "Upload a profile picture",
       "upload": "Choose Image",
       "change": "Change Image",
-      "uploading": "Uploading..."
+      "uploading": "Uploading...",
+      "cropTitle": "Crop Avatar"
     },
     "bio": {
       "title": "Tell Us About Yourself",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -543,7 +543,8 @@
       "description": "プロフィール画像をアップロードしてください",
       "upload": "画像を選択",
       "change": "画像を変更",
-      "uploading": "アップロード中..."
+      "uploading": "アップロード中...",
+      "cropTitle": "アバターをトリミング"
     },
     "bio": {
       "title": "自己紹介を設定",


### PR DESCRIPTION
### Motivation
- The setup wizard avatar step uploaded images without a cropping step, so this change brings the setup flow in line with the profile edit UI by adding a crop step before upload.

### Description
- Import and wire up `ImageCropDialog` in `apps/frontend/components/setup/AvatarStep.tsx` and add state to hold the dialog, the data-URL preview source, and the pending file.
- Change `handleFileSelect` to read the selected file as a Data URL and open the crop dialog instead of immediately setting a preview or uploading.
- Add `handleCropComplete` to receive the cropped `File`, set a preview URL and `selectedFile`, and close/reset the crop dialog; the existing `onNext` continues to receive the final file when the user advances.
- Add the setup-specific i18n key `setup.avatar.cropTitle` to `apps/frontend/messages/en.json` and `apps/frontend/messages/ja.json` and use it for the dialog title with a fixed `1:1` aspect ratio.

### Testing
- Ran `pnpm -C apps/frontend lint`, which completed successfully with `0` errors and repository warnings (lint command returned successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03e22fb0188333b310b048ab7a37d3)