### PR TITLE
Extract base image digest update policy into docs and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,24 +41,9 @@ docker compose build
 
 ### Base image digest update policy
 
-`Dockerfile.frontend` pins `node:22-bookworm-slim` by digest to keep image layers reproducible.
+To keep setup instructions focused, detailed policy guidance is documented separately:
 
-- Update the digest when you intentionally bump Node 22 slim base contents (security patches or monthly maintenance).
-- Keep `base` and `runner` on the same digest in `Dockerfile.frontend`.
-- Recommended update flow:
-
-```bash
-# 1) Fetch current amd64 digest for node:22-bookworm-slim
-TOKEN=$(curl -fsSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/node:pull" | jq -r .token)
-curl -fsSL -H "Authorization: Bearer $TOKEN" \
-  -H "Accept: application/vnd.oci.image.index.v1+json" \
-  https://registry-1.docker.io/v2/library/node/manifests/22-bookworm-slim \
-  | jq -r '.manifests[] | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest'
-
-# 2) Replace both FROM lines in Dockerfile.frontend
-# 3) Rebuild and verify
-docker compose build frontend
-```
+- [docs/base-image-digest-update-policy.md](docs/base-image-digest-update-policy.md)
 
 Initialize the database (run once on first setup):
 

--- a/docs/base-image-digest-update-policy.md
+++ b/docs/base-image-digest-update-policy.md
@@ -1,0 +1,49 @@
+# Base image digest update policy
+
+`Dockerfile.frontend` pins `node:22-bookworm-slim` by digest. This keeps image layers reproducible and prevents unintended base image drift.
+
+## Why we pin by digest
+
+- A tag alone (for example, `node:22-bookworm-slim`) can change over time.
+- Digest pinning ensures CI/CD, local development, and production all use the same base image.
+- Security updates are adopted intentionally on your schedule.
+
+## Update cadence
+
+Consider updating the digest when:
+
+- You want to adopt security patches in the Node 22 slim base image.
+- You perform monthly base image maintenance.
+- You revise runtime requirements in `Dockerfile.frontend`.
+
+## Required rule
+
+`base` and `runner` stages in `Dockerfile.frontend` must always use the same digest.
+
+## Recommended update flow
+
+1. Fetch the latest amd64 digest for `node:22-bookworm-slim`.
+2. Update both `FROM` lines in `Dockerfile.frontend` (`base` and `runner`) to that digest.
+3. Rebuild `frontend` and verify behavior.
+
+### 1) Fetch current amd64 digest
+
+```bash
+TOKEN=$(curl -fsSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/node:pull" | jq -r .token)
+curl -fsSL -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/vnd.oci.image.index.v1+json" \
+  https://registry-1.docker.io/v2/library/node/manifests/22-bookworm-slim \
+  | jq -r '.manifests[] | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest'
+```
+
+### 2) Replace both FROM lines in Dockerfile.frontend
+
+In `Dockerfile.frontend`, update the digest for both `base` and `runner` at the same time.
+
+### 3) Rebuild and verify
+
+```bash
+docker compose build frontend
+```
+
+If needed, run `docker compose up` and validate startup and runtime behavior.


### PR DESCRIPTION
### Motivation

- Keep the top-level `README.md` focused on setup steps by moving detailed policy guidance to a dedicated docs page. 
- Preserve the guidance for maintaining reproducible `node:22-bookworm-slim` base image digests while making it easier to find and update. 

### Description

- Removed the long inline "Base image digest update policy" section from `README.md` and replaced it with a link to the new docs page at `docs/base-image-digest-update-policy.md`. 
- Added `docs/base-image-digest-update-policy.md` containing the rationale, required rule that `base` and `runner` use the same digest, recommended update cadence, and an explicit three-step update flow with commands to fetch the amd64 digest and rebuild the frontend. 
- Kept the recommended commands for fetching the digest and rebuilding (`curl`/`jq` snippet and `docker compose build frontend`) in the new docs page. 

### Testing

- Ran the repository's automated CI checks including linters and markdown validation, and they completed successfully. 
- No code or runtime behavior was changed, so unit/integration tests were unaffected and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0689b4a37c8333a1602a3a60116069)