### PR TITLE
🐛 fix(backend): make authz migration tolerate existing settings

### DIFF
--- a/apps/backend/db/migrations/003_add_authz.up.sql
+++ b/apps/backend/db/migrations/003_add_authz.up.sql
@@ -53,6 +53,10 @@ CREATE TABLE IF NOT EXISTS server_settings (
   signup_enabled BOOLEAN NOT NULL DEFAULT TRUE
 );
 
+-- Existing databases may already have server_settings from schema.sql initialization.
+ALTER TABLE server_settings
+  ADD COLUMN IF NOT EXISTS signup_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+
 INSERT INTO roles (id, name, description) VALUES
   ('user', 'user', 'Default user role'),
   ('admin', 'admin', 'Administrator role')

--- a/apps/backend/tests/unit/db/migrations_test.go
+++ b/apps/backend/tests/unit/db/migrations_test.go
@@ -1,0 +1,30 @@
+package db_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestAuthzMigrationAddsSignupEnabledBeforeInsert(t *testing.T) {
+	sqlBytes, err := os.ReadFile("../../../db/migrations/003_add_authz.up.sql")
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+
+	sql := strings.ToLower(string(sqlBytes))
+	alterIdx := strings.Index(sql, "alter table server_settings")
+	insertIdx := strings.Index(sql, "insert into server_settings")
+	if alterIdx < 0 {
+		t.Fatalf("expected migration to alter existing server_settings")
+	}
+	if !strings.Contains(sql[alterIdx:], "add column if not exists signup_enabled") {
+		t.Fatalf("expected migration to add signup_enabled when server_settings already exists")
+	}
+	if insertIdx < 0 {
+		t.Fatalf("expected migration to insert default server_settings row")
+	}
+	if alterIdx > insertIdx {
+		t.Fatalf("expected signup_enabled column to be added before inserting server_settings")
+	}
+}


### PR DESCRIPTION
- Add signup_enabled when server_settings already exists
- Cover migration ordering with a unit test