### PR TITLE
fix(frontend): prevent timeline pages from being evicted by removing `maxPages` cap

### DIFF
--- a/apps/frontend/lib/hooks/use-queries.ts
+++ b/apps/frontend/lib/hooks/use-queries.ts
@@ -172,7 +172,6 @@ export function useTimeline(params?: { limit?: number }) {
     },
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
-    maxPages: 5,
     staleTime: 1000 * 60, // 1分
   });
 }
@@ -232,7 +231,6 @@ export function useUserPosts(
     },
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
-    maxPages: 5,
     enabled: !!username,
     staleTime: 1000 * 60, // 1分
   });


### PR DESCRIPTION
### Motivation
- Users who scrolled the timeline to the bottom then scrolled back saw only a partially loaded timeline because older pages were evicted from cache. 
- The intent is to preserve all loaded pages so scrolling back shows the full timeline content.

### Description
- Removed `maxPages: 5` from the timeline `useInfiniteQuery` in `apps/frontend/lib/hooks/use-queries.ts` so React Query no longer discards older pages.
- Removed the same `maxPages: 5` cap from the user posts infinite query in `apps/frontend/lib/hooks/use-queries.ts` to keep behavior consistent for profile lists.

### Testing
- Ran `pnpm -C apps/frontend lint`, which completed successfully with existing repository warnings and reported 0 errors, indicating no lint regressions from this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a071474b8748333bc72ee58913de70a)