### PR TITLE
fix: align emoji picker button style with other composer toolbar buttons

### DIFF
--- a/apps/frontend/components/post-composer/ComposerEmojiPicker.tsx
+++ b/apps/frontend/components/post-composer/ComposerEmojiPicker.tsx
@@ -64,9 +64,9 @@ export function ComposerEmojiPicker({
   const trigger = (
     <Button
       variant="ghost"
-      size="sm"
+      size="icon"
       disabled={disabled}
-      className={cn("p-0 text-muted-foreground transition-colors duration-160 ease hover:text-foreground", className)}
+      className={className}
       aria-label={t("addEmoji")}
     >
       <Smile className={cn("w-5 h-5", iconClassName)} />


### PR DESCRIPTION
Use size="icon" and remove hardcoded color overrides so the emoji button matches the h-9 w-9 dimensions and default ghost variant coloring of all other toolbar buttons.